### PR TITLE
Add web interface with upload features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 npm-debug.log
 .DS_Store
 .tmp/
+uploads/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecografias
 
-Sistema para disponibilizar ecografias online.
+Sistema para disponibilizar ecografias online com upload e visualização de imagens.
 
 ## Como iniciar o projeto
 
@@ -10,7 +10,16 @@ Sistema para disponibilizar ecografias online.
    ```
 2. Inicie o servidor:
    ```bash
-   node index.js
+   npm start
    ```
-
 O servidor iniciará na porta `3000` por padrão e servirá arquivos estáticos do diretório `public`.
+
+## API
+
+- `GET /api/ecografias` - lista todas as ecografias cadastradas.
+- `POST /api/ecografias` - envia uma nova ecografia (campo `file`).
+- `GET /uploads/<arquivo>` - acessa o arquivo enviado.
+
+## Interface Web
+
+A interface web disponível em `/` permite enviar novas ecografias e visualizar a lista de imagens cadastradas.

--- a/index.js
+++ b/index.js
@@ -1,14 +1,50 @@
 const express = require('express');
+const multer = require('multer');
 const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Serve static files from the public directory
+// Configuração do multer para uploads
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+
+// Armazena ecografias em memória
+const ecografias = [];
+
+// Servir arquivos estáticos
 app.use('/public', express.static(path.join(__dirname, 'public')));
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use(express.json());
 
 app.get('/', (req, res) => {
-  res.send('API de ecografias em execução');
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.get('/api/ecografias', (req, res) => {
+  res.json(ecografias);
+});
+
+app.post('/api/ecografias', upload.single('file'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Arquivo n\u00e3o enviado' });
+  }
+  const nova = {
+    id: ecografias.length + 1,
+    originalName: req.file.originalname,
+    filename: req.file.filename,
+    timestamp: Date.now()
+  };
+  ecografias.push(nova);
+  res.status(201).json(nova);
+});
+
+app.get('/api/ecografias/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const item = ecografias.find(e => e.id === id);
+  if (!item) {
+    return res.status(404).json({ error: 'Ecografia n\u00e3o encontrada' });
+  }
+  res.json(item);
 });
 
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "multer": "^2.0.1"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,54 @@
 <head>
   <meta charset="UTF-8">
   <title>Ecografias</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #lista div { margin-bottom: 20px; }
+    #lista img { max-width: 200px; display: block; }
+  </style>
 </head>
 <body>
-  <h1>Bem-vindo ao sistema de ecografias online</h1>
+  <h1>Ecografias Online</h1>
+
+  <h2>Enviar nova ecografia</h2>
+  <form id="uploadForm">
+    <input type="file" name="file" accept="image/*" required />
+    <button type="submit">Enviar</button>
+  </form>
+
+  <h2>Lista de ecografias</h2>
+  <div id="lista"></div>
+
+  <script>
+    async function carregarEcografias() {
+      const res = await fetch('/api/ecografias');
+      const data = await res.json();
+      const lista = document.getElementById('lista');
+      lista.innerHTML = '';
+      data.forEach(item => {
+        const div = document.createElement('div');
+        const img = document.createElement('img');
+        img.src = '/uploads/' + item.filename;
+        div.appendChild(img);
+        const p = document.createElement('p');
+        p.textContent = item.originalName;
+        div.appendChild(p);
+        lista.appendChild(div);
+      });
+    }
+
+    document.getElementById('uploadForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(e.target);
+      await fetch('/api/ecografias', {
+        method: 'POST',
+        body: formData
+      });
+      e.target.reset();
+      carregarEcografias();
+    });
+
+    carregarEcografias();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve web interface from `/` to upload and view ultrasound images
- provide REST API endpoints for listing and uploading images
- store uploads in `uploads/` directory using multer
- document new usage and API in README

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849d6cb88488329bb4b6515edfe63e4