### PR TITLE
Adiciona CPF e proteção para laudos compartilhados

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecografias
 
-Sistema para disponibilizar ecografias online com upload e visualização de imagens.
+Sistema para disponibilizar ecografias online com upload e visualização de laudos em PDF.
 
 ## Como iniciar o projeto
 
@@ -17,9 +17,10 @@ O servidor iniciará na porta `3000` por padrão e servirá arquivos estáticos 
 ## API
 
 - `GET /api/ecografias` - lista todas as ecografias cadastradas.
-- `POST /api/ecografias` - envia uma nova ecografia (campo `file`).
+- `POST /api/ecografias` - envia um novo laudo em PDF (campo `file`). O corpo também deve conter `patientName`, `cpf`, `examDate` e `notes`.
 - `GET /uploads/<arquivo>` - acessa o arquivo enviado.
 
 ## Interface Web
 
 A interface web disponível em `/` permite enviar novas ecografias e visualizar a lista de imagens cadastradas.
+Para que um paciente visualize seu laudo, um link de compartilhamento é gerado pelo administrador. O paciente precisa acessar esse link e informar o CPF cadastrado para liberar o PDF.

--- a/public/app.js
+++ b/public/app.js
@@ -39,9 +39,15 @@ if (uploadForm) {
     data.forEach((item) => {
       const div = document.createElement('div');
       div.className = 'card';
-      const img = document.createElement('img');
-      img.src = '/thumbs/' + item.thumbFilename;
-      div.appendChild(img);
+      if (item.thumbFilename) {
+        const img = document.createElement('img');
+        img.src = '/thumbs/' + item.thumbFilename;
+        div.appendChild(img);
+      } else {
+        const span = document.createElement('span');
+        span.textContent = 'PDF';
+        div.appendChild(span);
+      }
       const p = document.createElement('p');
       p.textContent = `${item.patientName} - ${item.examDate}`;
       div.appendChild(p);

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,10 @@
         <input type="text" name="patientName" required>
       </div>
       <div>
+        <label>CPF</label>
+        <input type="text" name="cpf" required>
+      </div>
+      <div>
         <label>Data do exame</label>
         <input type="date" name="examDate" required>
       </div>
@@ -26,13 +30,13 @@
         <textarea name="notes"></textarea>
       </div>
       <div>
-        <input type="file" name="file" accept="image/*" required />
+        <input type="file" name="file" accept="application/pdf" required />
       </div>
       <button type="submit">Enviar</button>
     </form>
 
     <h2>Busca</h2>
-    <input type="text" id="searchInput" placeholder="Nome do paciente ou observação" />
+    <input type="text" id="searchInput" placeholder="Nome, CPF ou observação" />
 
     <h2>Lista de ecografias</h2>
     <div id="lista" class="grid"></div>

--- a/public/share.html
+++ b/public/share.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <title>Laudo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><h1>Visualizar Laudo</h1></header>
+  <div class="container">
+    <p>Informe o CPF para acessar o arquivo.</p>
+    <form id="cpfForm">
+      <input type="text" id="cpfInput" placeholder="CPF" required />
+      <button type="submit">Visualizar</button>
+    </form>
+    <div id="error" style="color:red;"></div>
+    <div id="pdfContainer" class="pdf-container" style="display:none;">
+      <embed id="pdfEmbed" type="application/pdf" width="100%" height="600px" />
+    </div>
+  </div>
+  <script src="share.js"></script>
+</body>
+</html>

--- a/public/share.js
+++ b/public/share.js
@@ -1,0 +1,21 @@
+const form = document.getElementById('cpfForm');
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const cpf = document.getElementById('cpfInput').value.trim();
+    const res = await fetch(location.pathname, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cpf }),
+    });
+    if (res.ok) {
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      document.getElementById('pdfEmbed').src = url;
+      document.getElementById('pdfContainer').style.display = 'block';
+      form.style.display = 'none';
+    } else {
+      document.getElementById('error').textContent = 'CPF incorreto ou link expirado';
+    }
+  });
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,13 +1,13 @@
 body {
   font-family: Arial, sans-serif;
-  background: #f0f4f9;
+  background: linear-gradient(to right, #eef2f7, #cfd9e9);
   color: #333;
   margin: 0;
   padding: 0;
 }
 
 header {
-  background: #0066cc;
+  background: linear-gradient(90deg, #0066cc, #004999);
   color: white;
   padding: 20px;
   text-align: center;
@@ -30,6 +30,11 @@ header {
 
 .card {
   width: 200px;
+  background: #fafafa;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  text-align: center;
 }
 
 .card img {
@@ -63,4 +68,8 @@ button {
 
 button:hover {
   background: #004999;
+}
+
+.pdf-container {
+  margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- exige CPF ao cadastrar paciente
- armazena CPF e permite busca
- aceita PDFs no upload
- adiciona página protegida para visualização de laudos
- pequenas melhorias visuais

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6849dcfe3d288329b707566776eda373