### PR TITLE
Fix share page bug and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/uploads', express.static(UPLOAD_DIR));
 app.use('/thumbs', express.static(THUMB_DIR));
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(
   session({
     secret: 'keyboard cat',
@@ -210,6 +211,10 @@ app.post('/share/:token', (req, res) => {
   res.status(403).send('CPF incorreto');
 });
 
-app.listen(PORT, () => {
-  console.log(`Servidor iniciado na porta ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Servidor iniciado na porta ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sistema para disponibilizar ecografias online",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node index.js"
   },
   "keywords": [],
@@ -17,5 +17,9 @@
     "express-session": "^1.18.1",
     "multer": "^2.0.1",
     "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/public/share.html
+++ b/public/share.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Laudo</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body>
   <header><h1>Visualizar Laudo</h1></header>
@@ -13,11 +13,11 @@
       <input type="text" id="cpfInput" placeholder="CPF" required />
       <button type="submit">Visualizar</button>
     </form>
-    <div id="error" style="color:red;"></div>
+    <div id="error"></div>
     <div id="pdfContainer" class="pdf-container" style="display:none;">
       <embed id="pdfEmbed" type="application/pdf" width="100%" height="600px" />
     </div>
   </div>
-  <script src="share.js"></script>
+  <script src="/share.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -73,3 +73,8 @@ button:hover {
 .pdf-container {
   margin-top: 20px;
 }
+
+#error {
+  color: red;
+  margin-top: 10px;
+}

--- a/test/share.test.js
+++ b/test/share.test.js
@@ -1,0 +1,57 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const app = require('../index');
+
+const agent = request.agent(app);
+
+const pdfBuffer = Buffer.from('dummy');
+
+function createTempPdf() {
+  const file = path.join(__dirname, 'tmp.pdf');
+  fs.writeFileSync(file, pdfBuffer);
+  return file;
+}
+
+describe('Compartilhamento', () => {
+  let id;
+  let token;
+  const cpf = '12345678900';
+  beforeAll(async () => {
+    await agent
+      .post('/login')
+      .send({ username: 'admin', password: 'admin' })
+      .expect(200);
+
+    const tmpPdf = createTempPdf();
+    const res = await agent
+      .post('/api/ecografias')
+      .field('patientName', 'Teste')
+      .field('cpf', cpf)
+      .field('examDate', '2020-01-01')
+      .field('notes', 'teste')
+      .attach('file', tmpPdf);
+
+    fs.unlinkSync(tmpPdf);
+
+    id = res.body.id;
+
+    const shareRes = await agent.post(`/api/ecografias/${id}/share`).expect(200);
+    token = shareRes.body.url.split('/').pop();
+  });
+
+  test('deve aceitar CPF correto e retornar PDF', async () => {
+    const res = await agent
+      .post(`/share/${token}`)
+      .send({ cpf });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+  });
+
+  test('deve rejeitar CPF incorreto', async () => {
+    const res = await agent
+      .post(`/share/${token}`)
+      .send({ cpf: '000' });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- fix relative paths in the share page so CSS/JS load correctly
- parse url-encoded forms for robustness
- export the express app for testing
- improve error message styling
- add Jest & Supertest test suite covering share flow

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ded4ed90832986c6b041d8cff576