### PR TITLE
Adiciona botão de download para laudos

### DIFF
--- a/public/share.html
+++ b/public/share.html
@@ -25,6 +25,7 @@
     <div id="error"></div>
     <div id="pdfContainer" class="pdf-container" style="display:none;">
       <embed id="pdfEmbed" type="application/pdf" width="100%" style="height:80vh;" />
+      <a id="downloadLink" class="download-link" style="display:none;" download>Baixar PDF</a>
     </div>
   </div>
   <script src="/share.js"></script>

--- a/public/share.js
+++ b/public/share.js
@@ -27,6 +27,9 @@ if (form) {
       const url = URL.createObjectURL(blob);
       document.getElementById('pdfEmbed').src = url;
       document.getElementById('pdfContainer').style.display = 'block';
+      const link = document.getElementById('downloadLink');
+      link.href = url;
+      link.style.display = 'inline-block';
       form.style.display = 'none';
     } else {
       document.getElementById('error').textContent = 'CPF incorreto ou link expirado';

--- a/public/style.css
+++ b/public/style.css
@@ -167,6 +167,20 @@ button:hover {
   background: var(--primary-dark);
 }
 
+.download-link {
+  display: inline-block;
+  margin-top: 10px;
+  text-decoration: none;
+  background: var(--primary);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+}
+
+.download-link:hover {
+  background: var(--primary-dark);
+}
+
 .pdf-container {
   margin-top: 20px;
 }

--- a/test/share.test.js
+++ b/test/share.test.js
@@ -40,6 +40,12 @@ describe('Compartilhamento', () => {
     token = shareRes.body.url.split('/').pop();
   });
 
+  test('pagina de compartilhamento deve conter botao de download', async () => {
+    const res = await agent.get(`/share/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('id="downloadLink"');
+  });
+
   test('deve aceitar CPF correto e retornar PDF', async () => {
     const res = await agent
       .post(`/share/${token}`)


### PR DESCRIPTION
## Summary
- exibir botão de download no compartilhamento
- ajustar script para popular link
- estilizar botão de download
- testar a existência do botão

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa1eb14808329aa258c8215008699