### PR TITLE
Adicionar novas rotas de API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ O servidor iniciará na porta `3000` por padrão e servirá arquivos estáticos 
 - `GET /api/ecografias` - lista todas as ecografias cadastradas.
 - `POST /api/ecografias` - envia um novo laudo em PDF (campo `file`). O corpo também deve conter `patientName`, `cpf`, `whatsapp`, `examDate` e `notes`. Após o envio, um link de compartilhamento é enviado automaticamente para o WhatsApp informado.
 - `GET /uploads/<arquivo>` - acessa o arquivo enviado (requer autenticação).
+- `GET /api/message` - obtém o texto utilizado para envio via WhatsApp.
+- `POST /api/message` - atualiza o texto da mensagem enviada.
+- `GET /api/downloads` - lista registros de downloads.
+- `GET /api/stats` - retorna estatísticas gerais.
+- `GET /api/whatsapp/status` - informa se o WhatsApp está conectado.
+- `POST /api/whatsapp/reset` - reinicia a sessão do WhatsApp.
+- `GET /api/ecografias.csv` - exporta a lista de exames em CSV.
+- `POST /api/ecografias/:id/unshare` - desativa o compartilhamento de um exame.
+- `POST /api/users/:username/password` - altera a senha do usuário informado.
 
 ## Interface Web
 

--- a/test/extras.test.js
+++ b/test/extras.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const app = require('../index');
+
+const agent = request.agent(app);
+
+const pdfBuffer = Buffer.from('dummy');
+function createTempPdf() {
+  const file = path.join(__dirname, 'tmp2.pdf');
+  fs.writeFileSync(file, pdfBuffer);
+  return file;
+}
+
+describe('Novas funcionalidades', () => {
+  beforeAll(async () => {
+    await agent.post('/login').send({ username: 'admin', password: 'admin' });
+  });
+
+  test('mensagem pode ser atualizada', async () => {
+    const res = await agent.post('/api/message').send({ message: 'Teste {link}' });
+    expect(res.status).toBe(200);
+    const get = await agent.get('/api/message');
+    expect(get.body.message).toBe('Teste {link}');
+  });
+
+  test('stats e downloads funcionam', async () => {
+    const tmpPdf = createTempPdf();
+    const upload = await agent
+      .post('/api/ecografias')
+      .field('patientName', 'X')
+      .field('cpf', '1')
+      .field('examDate', '2020-01-01')
+      .field('notes', 'n')
+      .attach('file', tmpPdf);
+    fs.unlinkSync(tmpPdf);
+    const id = upload.body.id;
+    const share = await agent.post(`/api/ecografias/${id}/share`);
+    const token = share.body.url.split('/').pop();
+    await agent.post(`/share/${token}`).send({ cpf: '1' });
+    const d = await agent.get('/api/downloads');
+    expect(Array.isArray(d.body)).toBe(true);
+    const stats = await agent.get('/api/stats');
+    expect(stats.body.totalEcografias).toBeGreaterThan(0);
+    expect(stats.body.totalDownloads).toBeGreaterThanOrEqual(0);
+  });
+
+  test('senha de usuário pode ser alterada', async () => {
+    await agent.post('/api/users').send({ username: 'temp', password: '1' }).expect(200);
+    await agent
+      .post('/api/users/temp/password')
+      .send({ password: '2' })
+      .expect(200);
+    await agent.delete('/api/users/temp').expect(200);
+  });
+});


### PR DESCRIPTION
## Resumo
- adicionar rotas de mensagem, downloads, estatísticas e csv
- permitir reset e status do WhatsApp
- acrescentar alteração de senha de usuário
- permitir exportar PDF via nova rota
- permitir desfazer compartilhamento
- criar testes automatizados para novas rotas

## Testes
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa3d4ee74832998b45b07dd952e34