### PR TITLE
Remove imagem local do botão Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ A interface web disponível em `/` permite enviar novas ecografias e visualizar 
 Para que um paciente visualize seu laudo, um link de compartilhamento é gerado pelo administrador. O paciente precisa acessar esse link e informar o CPF cadastrado para liberar o PDF.
 
 Ao iniciar o servidor é exibido um QR code no terminal para conectar o WhatsApp Web. A conta associada será utilizada para enviar automaticamente o link do laudo para o número informado no cadastro.
+
+## Login com Google
+
+Para habilitar o login via Google é necessário criar credenciais OAuth 2.0 no Google Cloud.
+
+1. Acesse [console.cloud.google.com](https://console.cloud.google.com/) e crie um projeto.
+2. Ative a API **Google Identity** e crie um ID do cliente OAuth do tipo **Aplicativo da Web**.
+3. Defina `http://localhost:3000/auth/google/callback` como URL de redirecionamento autorizada.
+4. Anote o **Client ID** e o **Client Secret** gerados.
+
+Antes de iniciar o servidor defina as variáveis de ambiente abaixo com os valores obtidos:
+
+```bash
+export GOOGLE_CLIENT_ID="seu_id"
+export GOOGLE_CLIENT_SECRET="sua_chave"
+npm start
+```
+
+Essas chaves não devem ser versionadas.

--- a/public/login.html
+++ b/public/login.html
@@ -28,7 +28,10 @@
       </div>
       <div class="login-buttons">
         <button type="submit">Entrar</button>
-        <a href="/auth/google" class="google-btn">Entrar com Google</a>
+        <a href="/auth/google" class="google-btn">
+          <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google">
+          <span>Entrar com Google</span>
+        </a>
       </div>
     </form>
     <div id="loginError" style="color:red;"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -263,9 +263,22 @@ button:hover {
 }
 
 .google-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   background: #fff;
   color: #444;
   border: 1px solid #ccc;
+  padding: 0 12px;
+  height: 40px;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.google-btn img {
+  width: 18px;
+  height: 18px;
 }
 
 .google-btn:hover {


### PR DESCRIPTION
## Summary
- remove o arquivo `g-logo.png`
- usa imagem hospedada pelo Google no botão de login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aaa1b700483299707a8c454b0dff4