### PR TITLE
Corrige callback do Google e visual do botão

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Para habilitar o login via Google é necessário criar credenciais OAuth 2.0 no 
 
 1. Acesse [console.cloud.google.com](https://console.cloud.google.com/) e crie um projeto.
 2. Ative a API **Google Identity** e crie um ID do cliente OAuth do tipo **Aplicativo da Web**.
-3. Defina `http://localhost:3000/auth/google/callback` como URL de redirecionamento autorizada.
+3. Defina `http://localhost:3000/auth/google/callback` como URL de redirecionamento autorizada (para uso local).
 4. Anote o **Client ID** e o **Client Secret** gerados.
 
 Antes de iniciar o servidor defina as variáveis de ambiente abaixo com os valores obtidos:
@@ -50,6 +50,7 @@ Antes de iniciar o servidor defina as variáveis de ambiente abaixo com os valor
 ```bash
 export GOOGLE_CLIENT_ID="seu_id"
 export GOOGLE_CLIENT_SECRET="sua_chave"
+export GOOGLE_CALLBACK_URL="https://sua.url/auth/google/callback"
 npm start
 ```
 

--- a/index.js
+++ b/index.js
@@ -148,12 +148,15 @@ app.use(passport.initialize());
 app.use(passport.session());
 passport.serializeUser((user, done) => done(null, user));
 passport.deserializeUser((obj, done) => done(null, obj));
+const GOOGLE_CALLBACK_URL =
+  process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback';
+
 passport.use(
   new GoogleStrategy(
     {
       clientID: process.env.GOOGLE_CLIENT_ID || 'dummy',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'dummy',
-      callbackURL: '/auth/google/callback',
+      callbackURL: GOOGLE_CALLBACK_URL,
     },
     (accessToken, refreshToken, profile, done) => {
       const email =
@@ -550,3 +553,4 @@ if (require.main === module) {
 }
 
 module.exports = app;
+module.exports.getGoogleCallbackURL = () => GOOGLE_CALLBACK_URL;

--- a/public/login.html
+++ b/public/login.html
@@ -28,7 +28,7 @@
       </div>
       <div class="login-buttons">
         <button type="submit">Entrar</button>
-        <a href="/auth/google" class="google-btn">
+        <a href="/auth/google" class="google-btn" role="button">
           <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google">
           <span>Entrar com Google</span>
         </a>

--- a/public/style.css
+++ b/public/style.css
@@ -265,15 +265,18 @@ button:hover {
 .google-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   background: #fff;
   color: #444;
   border: 1px solid #ccc;
-  padding: 0 12px;
+  padding: 0 16px;
   height: 40px;
   border-radius: 4px;
   text-decoration: none;
   font-weight: 500;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 .google-btn img {
@@ -282,5 +285,5 @@ button:hover {
 }
 
 .google-btn:hover {
-  background: #f2f2f2;
+  background: #f7f7f7;
 }

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -1,10 +1,19 @@
 const request = require('supertest');
-const app = require('../index');
+let app = require('../index');
 
 describe('Login Google', () => {
   test('rota de auth redireciona para o Google', async () => {
     const res = await request(app).get('/auth/google');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('accounts.google.com');
+  });
+
+  test('callback respeita variavel de ambiente', async () => {
+    process.env.GOOGLE_CALLBACK_URL = '/cbtest';
+    jest.resetModules();
+    app = require('../index');
+    const res = await request(app).get('/auth/google');
+    expect(res.headers.location).toContain(encodeURIComponent('/cbtest'));
+    delete process.env.GOOGLE_CALLBACK_URL;
   });
 });


### PR DESCRIPTION
## Resumo
- permite configurar a URL de callback do Google via `GOOGLE_CALLBACK_URL`
- melhora estilo do botão "Entrar com Google"
- adiciona teste garantindo o uso da nova variável

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aafd3d6708329855b7b2473ddbdec