### PR TITLE
Implementação de permissões de usuário

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Para executar a suíte de testes utilize `npm test`.
 ## Interface Web
 
 A interface web disponível em `/` permite enviar novas ecografias e visualizar a lista de imagens cadastradas.
+Os usuários possuem papéis de **admin**, **medico** ou **paciente**. Somente administradores conseguem gerenciar usuários.
+Pacientes enxergam apenas seus próprios exames.
 Para que um paciente visualize seu laudo, um link de compartilhamento é gerado pelo administrador. O paciente precisa acessar esse link e informar o CPF cadastrado para liberar o PDF.
 
 Ao iniciar o servidor é exibido um QR code no terminal para conectar o WhatsApp Web. A conta associada será utilizada para enviar automaticamente o link do laudo para o número informado no cadastro.

--- a/public/app.js
+++ b/public/app.js
@@ -43,6 +43,23 @@ if (loginForm) {
 // Index page
 const uploadForm = document.getElementById('uploadForm');
 if (uploadForm) {
+  (async function initIndex() {
+    let userRole = 'medico';
+    try {
+      const meRes = await api('/api/me');
+      const me = await meRes.json();
+      userRole = me.role;
+    } catch (_) {}
+
+    if (userRole !== 'admin') {
+      document.querySelector('[data-tab="usuarios"]').style.display = 'none';
+    }
+    if (userRole === 'paciente') {
+      document.querySelector('[data-tab="upload"]').style.display = 'none';
+      document.querySelector('[data-tab="mensagem"]').style.display = 'none';
+      document.querySelector('[data-tab="stats"]').style.display = 'none';
+    }
+
   const lista = document.getElementById('lista');
   const tbody = lista.querySelector('tbody');
   const searchInput = document.getElementById('searchInput');
@@ -133,11 +150,15 @@ if (uploadForm) {
       pdfLink.textContent = 'PDF';
       pdfLink.href = `/api/ecografias/${item.id}/pdf`;
       pdfLink.target = '_blank';
-      actionsTd.appendChild(shareBtn);
-      actionsTd.appendChild(resendBtn);
-      actionsTd.appendChild(delBtn);
-      actionsTd.appendChild(unshareBtn);
-      actionsTd.appendChild(pdfLink);
+      if (userRole === 'paciente') {
+        actionsTd.appendChild(pdfLink);
+      } else {
+        actionsTd.appendChild(shareBtn);
+        actionsTd.appendChild(resendBtn);
+        actionsTd.appendChild(delBtn);
+        actionsTd.appendChild(unshareBtn);
+        actionsTd.appendChild(pdfLink);
+      }
       tr.appendChild(previewTd);
       tr.appendChild(patientTd);
       tr.appendChild(dateTd);
@@ -173,8 +194,21 @@ if (uploadForm) {
         await api(`/api/users/${u}`, { method: 'DELETE' });
         loadUsers();
       };
+      const roleBtn = document.createElement('button');
+      roleBtn.textContent = 'Papel';
+      roleBtn.onclick = async () => {
+        const role = prompt('admin, medico ou paciente?');
+        if (role) {
+          await api(`/api/users/${u}/role`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ role }),
+          });
+        }
+      };
       actTd.appendChild(passBtn);
       actTd.appendChild(delBtn);
+      actTd.appendChild(roleBtn);
       tr.appendChild(nameTd);
       tr.appendChild(actTd);
       userList.appendChild(tr);
@@ -263,4 +297,5 @@ if (uploadForm) {
 
   searchInput.addEventListener('input', () => carregar(searchInput.value));
   carregar();
+  })();
 }

--- a/public/index.html
+++ b/public/index.html
@@ -85,6 +85,11 @@
       <form id="userForm">
         <input type="text" name="username" placeholder="Usuario" required />
         <input type="password" name="password" placeholder="Senha" required />
+        <select name="role">
+          <option value="medico">Medico</option>
+          <option value="paciente">Paciente</option>
+          <option value="admin">Admin</option>
+        </select>
         <button type="submit">Adicionar</button>
       </form>
       <div class="table-wrapper">

--- a/test/roles.test.js
+++ b/test/roles.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest');
+const app = require('../index');
+
+const agent = request.agent(app);
+
+describe('Permissoes', () => {
+  beforeAll(async () => {
+    await agent.post('/login').send({ username: 'admin', password: 'admin' });
+  });
+
+  test('endpoint me', async () => {
+    const res = await agent.get('/api/me');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('username', 'admin');
+    expect(res.body).toHaveProperty('role');
+  });
+
+  test('bloqueia usuarios para nao admin', async () => {
+    await agent.post('/api/users').send({ username: 'med', password: '1', role: 'medico' });
+    const med = request.agent(app);
+    await med.post('/login').send({ username: 'med', password: '1' });
+    const res = await med.get('/api/users');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- adicionar níveis de usuário (admin, medico e paciente)
- restringir rotas via `requireRole`
- criar endpoint `/api/me`
- filtrar exames para pacientes
- atualizar interface para esconder abas conforme o papel do usuário
- permitir definir papel na criação de usuários
- adicionar testes de permissões

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abe955a0883298d61ca1bba92d3bd