### PR TITLE
Implementa painel de exames e menu de perfil

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,12 @@
     <h1>EcoShare</h1>
     <div class="header-buttons">
       <button id="themeToggle">Tema</button>
-      <button id="logoutBtn">Sair</button>
+      <div class="profile-menu">
+        <img id="profilePic" class="profile-pic" src="" alt="Perfil">
+        <div id="profileDropdown" class="profile-dropdown">
+          <button id="logoutBtn">Sair</button>
+        </div>
+      </div>
     </div>
   </header>
   <div class="container glass">

--- a/public/painel.html
+++ b/public/painel.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CPF - EcoShare</title>
+  <title>Painel - EcoShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -22,15 +22,9 @@
       </div>
     </div>
   </header>
-  <div class="container glass login-container">
-    <form id="cpfForm" method="post" action="/api/me/cpf">
-      <div>
-        <label>CPF</label>
-        <input type="text" name="cpf" required>
-      </div>
-      <button type="submit">Salvar</button>
-    </form>
-    <div id="cpfError" style="color:red;"></div>
+  <div class="container glass" id="painel">
+    <h2>Meus Exames</h2>
+    <div id="examGrid" class="grid"></div>
   </div>
   <footer class="footer glass">
     <a href="/politica">Política de Privacidade</a>

--- a/public/share.html
+++ b/public/share.html
@@ -14,6 +14,12 @@
     <h1>Visualizar Laudo</h1>
     <div class="header-buttons">
       <button id="themeToggle">Tema</button>
+      <div class="profile-menu">
+        <img id="profilePic" class="profile-pic" src="" alt="Perfil">
+        <div id="profileDropdown" class="profile-dropdown">
+          <button id="logoutBtn">Sair</button>
+        </div>
+      </div>
     </div>
   </header>
   <div class="container glass">

--- a/public/share.js
+++ b/public/share.js
@@ -12,6 +12,29 @@ function initTheme() {
 
 initTheme();
 
+async function initProfileMenu() {
+  const pic = document.getElementById('profilePic');
+  const dropdown = document.getElementById('profileDropdown');
+  if (!pic) return;
+  try {
+    const res = await fetch('/api/me');
+    if (res.ok) {
+      const me = await res.json();
+      if (me.picture) pic.src = me.picture;
+    }
+  } catch (_) {}
+  pic.addEventListener('click', () => {
+    dropdown.classList.toggle('show');
+  });
+  document.addEventListener('click', (e) => {
+    if (e.target !== pic && !dropdown.contains(e.target)) {
+      dropdown.classList.remove('show');
+    }
+  });
+}
+
+initProfileMenu();
+
 const form = document.getElementById('cpfForm');
 if (form) {
   form.addEventListener('submit', async (e) => {

--- a/public/style.css
+++ b/public/style.css
@@ -304,3 +304,34 @@ footer.footer {
 .footer a:hover {
   text-decoration: underline;
 }
+.profile-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.profile-pic {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.profile-dropdown {
+  display: none;
+  position: absolute;
+  right: 0;
+  background: #fff;
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+body.dark .profile-dropdown {
+  background: #333;
+  color: var(--text-dark);
+  border-color: #444;
+}
+
+.profile-dropdown.show {
+  display: block;
+}


### PR DESCRIPTION
## Resumo
- adiciona nova página `painel.html` para pacientes
- exibe foto do usuário em todas as páginas com menu suspenso de logout
- cria função `initProfileMenu` e painel de exames em `app.js`
- ajusta redirecionamento após salvar CPF
- atualiza estilos para o menu de perfil

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac8ebade48329af353076f29f1bb0