### PR TITLE
Implementa painel exclusivo para pacientes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -54,7 +54,14 @@ if (loginForm) {
       body: JSON.stringify(data),
     }).catch(() => {});
     if (res && res.ok) {
-      location.href = "/index.html";
+      const data = await res.json();
+      if (data.needCpf) {
+        location.href = '/cpf.html';
+      } else if (data.role === 'paciente') {
+        location.href = '/painel.html';
+      } else {
+        location.href = '/index.html';
+      }
     } else if (res) {
       document.getElementById('loginError').textContent = 'Falha no login';
     }

--- a/public/style.css
+++ b/public/style.css
@@ -320,10 +320,12 @@ footer.footer {
   display: none;
   position: absolute;
   right: 0;
+  top: calc(100% + 5px);
   background: #fff;
   padding: 5px;
   border: 1px solid #ccc;
   border-radius: 4px;
+  z-index: 1000;
 }
 
 body.dark .profile-dropdown {

--- a/test/painel_redirect.test.js
+++ b/test/painel_redirect.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const app = require('../index');
+
+const admin = request.agent(app);
+const patient = request.agent(app);
+
+beforeAll(async () => {
+  await admin.post('/login').send({ username: 'admin', password: 'admin' });
+  await admin.post('/api/users').send({ username: 'pac', password: '1', role: 'paciente' });
+  await patient.post('/login').send({ username: 'pac', password: '1' });
+  await patient.post('/api/me/cpf').send({ cpf: '123' });
+});
+
+afterAll(async () => {
+  await admin.delete('/api/users/pac');
+});
+
+test('paciente recebe painel ao acessar root', async () => {
+  const res = await patient.get('/');
+  expect(res.status).toBe(200);
+  expect(res.text).toContain('Meus Exames');
+  expect(res.text).not.toContain('Enviar nova ecografia');
+});


### PR DESCRIPTION
## Resumo
- exibe painel simplificado quando o usuário é paciente
- login informa o papel e se o CPF é obrigatório
- redireciona pacientes via JavaScript
- corrige exibição do menu de perfil
- adiciona teste garantindo o painel para pacientes

## Resultados dos testes
```
PASS test/pages.test.js
PASS test/painel_redirect.test.js
PASS test/share.test.js
PASS test/extras.test.js
PASS test/users.test.js
PASS test/google.test.js
PASS test/roles.test.js
PASS test/extra2.test.js
PASS test/google_callback.test.js
PASS test/cpf_save.test.js

Test Suites: 10 passed, 10 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        3.746 s, estimated 4 s
Ran all test suites.
```

------
https://chatgpt.com/codex/tasks/task_e_684acb9fed1c8329b7504f659629cb4c