### PR TITLE
Corrige imagens de login e perfil

### DIFF
--- a/test/pages.test.js
+++ b/test/pages.test.js
@@ -27,4 +27,10 @@ describe('Paginas publicas', () => {
     expect(res.text).toContain('id="loginForm"');
     expect(res.text).toContain('action="/login"');
   });
+
+  test('login usa imagem de placeholder', async () => {
+    const res = await request(app).get('/login.html');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('https://placehold.co/18x18');
+  });
 });

--- a/test/profile_image.test.js
+++ b/test/profile_image.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const app = require('../index');
+
+const agent = request.agent(app);
+
+describe('Imagem de perfil', () => {
+  beforeAll(async () => {
+    await agent.post('/login').send({ username: 'admin', password: 'admin' });
+  });
+
+  test('header usa placeholder de perfil', async () => {
+    const res = await agent.get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('https://placehold.co/32x32');
+  });
+});

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -24,7 +24,7 @@
       <div class="login-buttons">
         <button type="submit">Entrar</button>
         <a href="/auth/google" class="google-btn" role="button">
-          <img src="https://developers.google.com/identity/images/g-logo.png" alt="Google">
+          <img src="https://placehold.co/18x18" alt="Google">
           <span>Entrar com Google</span>
         </a>
       </div>

--- a/views/partials/header_main.ejs
+++ b/views/partials/header_main.ejs
@@ -2,7 +2,7 @@
   <h1><%= title || 'EcoShare' %></h1>
   <div class="header-buttons">
     <div class="profile-menu">
-      <img id="profilePic" class="profile-pic" src="" alt="Perfil">
+      <img id="profilePic" class="profile-pic" src="https://placehold.co/32x32" alt="Perfil">
       <div id="profileDropdown" class="profile-dropdown">
         <button id="logoutBtn">Sair</button>
       </div>


### PR DESCRIPTION
## Resumo
- remove imagens binárias de login e perfil
- usa placeholders do serviço placehold.co nos templates
- verifica placeholders nos testes

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ada195460832980508290be16af6b