### PR TITLE
Ajuste de CSP para imagens externas

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,16 @@ const upload = multer({
 const SESSION_SECRET =
   process.env.SESSION_SECRET || require('crypto').randomBytes(16).toString('hex');
 
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+        'img-src': ["'self'", 'data:', 'https:'],
+      },
+    },
+  })
+);
 app.use(express.static(path.join(__dirname, 'public'), { index: false }));
 app.use('/thumbs', express.static(THUMB_DIR));
 app.use(express.json());

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('Content Security Policy', () => {
+  test('permite imagens externas', async () => {
+    const res = await request(app).get('/login.html');
+    expect(res.status).toBe(200);
+    const csp = res.headers['content-security-policy'];
+    expect(csp).toBeDefined();
+    expect(csp).toMatch(/img-src[^;]*https:/);
+  });
+});


### PR DESCRIPTION
## Summary
- permitir imagens remotas no Content Security Policy
- adicionar teste garantindo que CSP inclui `https:` na diretiva `img-src`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af60a07408329885496a3135f0f69