### PR TITLE
Clean share tokens on exam removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -633,6 +633,9 @@ app.delete('/api/ecografias/:id', requireRole(['admin', 'medico']), (req, res) =
   if (item.thumbFilename) {
     fs.unlinkSync(path.join(THUMB_DIR, item.thumbFilename));
   }
+  for (const [t, data] of Object.entries(shares)) {
+    if (data.id === id) delete shares[t];
+  }
   fs.writeFileSync(DB_PATH, JSON.stringify(ecografias, null, 2));
   logAction(`delete ${req.session.user.username} ${item.filename}`);
   res.json({ ok: true });

--- a/test/delete_share_cleanup.test.js
+++ b/test/delete_share_cleanup.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const app = require('../index');
+
+const agent = request.agent(app);
+const pdfBuffer = Buffer.from('cleanup');
+
+function tempPdf() {
+  const file = path.join(__dirname, 'cleanup.pdf');
+  fs.writeFileSync(file, pdfBuffer);
+  return file;
+}
+
+describe('Remocao de tokens ao deletar exame', () => {
+  let token;
+
+  beforeAll(async () => {
+    await agent.post('/login').send({ username: 'admin', password: 'admin' });
+    const tmp = tempPdf();
+    const upload = await agent
+      .post('/api/ecografias')
+      .field('patientName', 'Del')
+      .field('cpf', '1')
+      .field('examDate', '2020-01-01')
+      .field('notes', 'n')
+      .attach('file', tmp);
+    fs.unlinkSync(tmp);
+    const id = upload.body.id;
+    const share = await agent.post(`/api/ecografias/${id}/share`);
+    token = share.body.url.split('/').pop();
+    await agent.delete(`/api/ecografias/${id}`).expect(200);
+  });
+
+  test('token fica invalido apos exclusao', async () => {
+    const res = await agent.get(`/share/${token}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- purge share tokens in `/api/ecografias/:id` delete route
- test token removal when deleting an exam

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aff9500608329a1867693cd042f6c