### PR TITLE
Update role permissions on stats tab

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -104,11 +104,11 @@ if (uploadForm) {
 
     if (userRole !== 'admin') {
       document.querySelector('[data-tab="usuarios"]').style.display = 'none';
+      document.querySelector('[data-tab="stats"]').style.display = 'none';
     }
     if (userRole === 'paciente') {
       document.querySelector('[data-tab="upload"]').style.display = 'none';
       document.querySelector('[data-tab="mensagem"]').style.display = 'none';
-      document.querySelector('[data-tab="stats"]').style.display = 'none';
     }
 
   const lista = document.getElementById('lista');

--- a/test/stats_tab.test.js
+++ b/test/stats_tab.test.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Interface do painel', () => {
+  test('aba de estatisticas escondida para nao admin', () => {
+    const appJs = fs.readFileSync(path.join(__dirname, '../public/app.js'), 'utf8');
+    const regex = /userRole !== 'admin'[\s\S]*\[data-tab="stats"\]/;
+    expect(regex.test(appJs)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- hide the Estatisticas tab for todos que não são admin
- test to ensure script includes a checagem para ocultar a aba

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aff8595708329bf0772f9805826d3