### PR TITLE
Corrige thumb de PDF

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const sharp = require('sharp');
 const session = require('express-session');
 const helmet = require('helmet');
 const archiver = require('archiver');
-const pdfThumb = require('pdf-thumbnail');
+const gm = require('gm');
 const { Client, LocalAuth } = require('whatsapp-web.js');
 const qrcode = require('qrcode-terminal');
 const bcrypt = require('bcryptjs');
@@ -571,12 +571,14 @@ app.post(
   } else if (req.file.mimetype === 'application/pdf') {
     thumbFilename = 'thumb-' + filename.replace(path.extname(filename), '.png');
     try {
-      const stream = await pdfThumb(fs.readFileSync(req.file.path), { resize: { width: 200 } });
       await new Promise((resolve, reject) => {
-        const out = fs.createWriteStream(path.join(THUMB_DIR, thumbFilename));
-        stream.pipe(out);
-        out.on('finish', resolve);
-        out.on('error', reject);
+        gm(req.file.path + '[0]')
+          .setFormat('png')
+          .resize(200)
+          .write(path.join(THUMB_DIR, thumbFilename), (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
       });
     } catch (err) {
       console.error('Erro ao gerar miniatura do PDF:', err.message);

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "express-basic-auth": "^1.2.1",
     "express-session": "^1.18.1",
     "googleapis": "^98.0.0",
+    "helmet": "^7.0.0",
     "multer": "^2.0.1",
-    "pdf-thumbnail": "^1.0.6",
+    "gm": "^1.23.1",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.2",
-    "whatsapp-web.js": "^1.30.0",
-    "helmet": "^7.0.0"
+    "whatsapp-web.js": "^1.30.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- substituir `pdf-thumbnail` por `gm` para criar miniaturas de PDFs
- registrar dependência `gm` no `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b012fe6f483298214beca48e0fa77