### PR TITLE
Refatora botoes sem onclick

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -99,6 +99,13 @@ function makeDraggable(win) {
 
 document.querySelectorAll('.window').forEach(makeDraggable);
 document.querySelectorAll('.dock-icon').forEach((i) => i.addEventListener('click', () => openWindow(i.dataset.window)));
+document.querySelectorAll('.window-actions button').forEach((btn) => {
+  const target = btn.dataset.target;
+  const action = btn.dataset.action;
+  if (target && action === 'minimize') btn.addEventListener('click', () => minimizeWindow(target));
+  if (target && action === 'maximize') btn.addEventListener('click', () => maximizeWindow(target));
+  if (target && action === 'close') btn.addEventListener('click', () => closeWindow(target));
+});
 
 window.openWindow = openWindow;
 window.closeWindow = closeWindow;

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -1,8 +1,11 @@
 const request = require('supertest');
 const app = require('../index');
 
+const agent = request.agent(app);
+
 beforeAll(async () => {
   await app.ready;
+  await agent.post('/login').send({ username: 'admin', password: 'admin' });
 });
 
 describe('Content Security Policy', () => {
@@ -12,5 +15,11 @@ describe('Content Security Policy', () => {
     const csp = res.headers['content-security-policy'];
     expect(csp).toBeDefined();
     expect(csp).toMatch(/img-src[^;]*https:/);
+  });
+
+  test('pagina inicial nao usa onclick', async () => {
+    const res = await agent.get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('onclick=');
   });
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -24,9 +24,9 @@
       <div class="window-header">
         <span>Enviar</span>
         <div class="window-actions">
-          <button class="min-btn" onclick="minimizeWindow('upload')"></button>
-          <button class="max-btn" onclick="maximizeWindow('upload')"></button>
-          <button class="close-btn" onclick="closeWindow('upload')"></button>
+          <button class="min-btn" data-target="upload" data-action="minimize"></button>
+          <button class="max-btn" data-target="upload" data-action="maximize"></button>
+          <button class="close-btn" data-target="upload" data-action="close"></button>
         </div>
       </div>
       <div class="window-body">
@@ -65,9 +65,9 @@
       <div class="window-header">
         <span>Lista</span>
         <div class="window-actions">
-          <button class="min-btn" onclick="minimizeWindow('lista')"></button>
-          <button class="max-btn" onclick="maximizeWindow('lista')"></button>
-          <button class="close-btn" onclick="closeWindow('lista')"></button>
+          <button class="min-btn" data-target="lista" data-action="minimize"></button>
+          <button class="max-btn" data-target="lista" data-action="maximize"></button>
+          <button class="close-btn" data-target="lista" data-action="close"></button>
         </div>
       </div>
       <div class="window-body">
@@ -103,9 +103,9 @@
       <div class="window-header">
         <span>Usuarios</span>
         <div class="window-actions">
-          <button class="min-btn" onclick="minimizeWindow('usuarios')"></button>
-          <button class="max-btn" onclick="maximizeWindow('usuarios')"></button>
-          <button class="close-btn" onclick="closeWindow('usuarios')"></button>
+          <button class="min-btn" data-target="usuarios" data-action="minimize"></button>
+          <button class="max-btn" data-target="usuarios" data-action="maximize"></button>
+          <button class="close-btn" data-target="usuarios" data-action="close"></button>
         </div>
       </div>
       <div class="window-body">
@@ -134,9 +134,9 @@
       <div class="window-header">
         <span>Mensagem</span>
         <div class="window-actions">
-          <button class="min-btn" onclick="minimizeWindow('mensagem')"></button>
-          <button class="max-btn" onclick="maximizeWindow('mensagem')"></button>
-          <button class="close-btn" onclick="closeWindow('mensagem')"></button>
+          <button class="min-btn" data-target="mensagem" data-action="minimize"></button>
+          <button class="max-btn" data-target="mensagem" data-action="maximize"></button>
+          <button class="close-btn" data-target="mensagem" data-action="close"></button>
         </div>
       </div>
       <div class="window-body">
@@ -151,9 +151,9 @@
       <div class="window-header">
         <span>Estatisticas</span>
         <div class="window-actions">
-          <button class="min-btn" onclick="minimizeWindow('stats')"></button>
-          <button class="max-btn" onclick="maximizeWindow('stats')"></button>
-          <button class="close-btn" onclick="closeWindow('stats')"></button>
+          <button class="min-btn" data-target="stats" data-action="minimize"></button>
+          <button class="max-btn" data-target="stats" data-action="maximize"></button>
+          <button class="close-btn" data-target="stats" data-action="close"></button>
         </div>
       </div>
       <div class="window-body">


### PR DESCRIPTION
## Resumo
- remove `onclick` inline em `index.ejs`
- cria associacao de eventos para botoes de janela em `app.js`
- adiciona teste para garantir ausencia de `onclick` apos login

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb561cf248329a8ad1a00acc56a5e