### PR TITLE
Implementa menu em lista no app Gestão

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -203,7 +203,9 @@ if (uploadForm) {
   const shareClose = document.getElementById('shareClose');
   const qrCanvas = document.getElementById('qrCanvas');
   const icons = document.querySelectorAll('.dock-icon');
-  const menuBtns = document.querySelectorAll('.gestao-menu button');
+  const menu = document.querySelector('.gestao-menu');
+  const menuItems = document.querySelectorAll('.gestao-menu .item');
+  const backBtn = document.getElementById('gestaoBack');
   const sections = document.querySelectorAll('.gestao-section');
   const userForm = document.getElementById('userForm');
   const userList = document.querySelector('#userList tbody');
@@ -219,14 +221,25 @@ if (uploadForm) {
     icon.addEventListener('click', () => openWindow(icon.dataset.window));
   });
 
+  function showList() {
+    menu.style.display = 'block';
+    backBtn.style.display = 'none';
+    sections.forEach((s) => {
+      s.style.display = 'none';
+    });
+  }
+
   function showSection(id) {
+    menu.style.display = 'none';
+    backBtn.style.display = 'block';
     sections.forEach((s) => {
       s.style.display = s.id === id ? 'block' : 'none';
     });
   }
 
-  menuBtns.forEach((b) => b.addEventListener('click', () => showSection(b.dataset.section)));
-  showSection('uploadSection');
+  menuItems.forEach((i) => i.addEventListener('click', () => showSection(i.dataset.section)));
+  if (backBtn) backBtn.addEventListener('click', showList);
+  showList();
 
   if (shareClose) {
     shareClose.addEventListener('click', () => {

--- a/public/style.css
+++ b/public/style.css
@@ -569,19 +569,28 @@ footer.footer {
 
 .gestao-menu {
   display: flex;
-  gap: 6px;
-  margin-bottom: 10px;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
 }
 
-.gestao-menu button {
-  padding: 6px 10px;
-  border: 1px solid var(--border);
-  background: var(--neutral-bg);
-  border-radius: var(--radius-sm);
+.gestao-menu .item {
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
   cursor: pointer;
 }
 
-.gestao-menu button:hover {
+.gestao-menu .item:last-child {
+  border-bottom: none;
+}
+
+.gestao-menu .item:hover {
   background: var(--primary);
   color: #fff;
+}
+
+.gestao-back {
+  cursor: pointer;
+  margin-bottom: 10px;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -22,13 +22,14 @@
     </div>
     <div class="window-body gestao-body">
       <div class="gestao-menu">
-        <button data-section="uploadSection">Enviar</button>
-        <button data-section="listaSection">Lista</button>
-        <button data-section="usuariosSection">Usuarios</button>
-        <button data-section="mensagemSection">Mensagem</button>
-        <button data-section="statsSection">Estatisticas</button>
+        <div class="item" data-section="uploadSection">Enviar</div>
+        <div class="item" data-section="listaSection">Lista</div>
+        <div class="item" data-section="usuariosSection">Usuarios</div>
+        <div class="item" data-section="mensagemSection">Mensagem</div>
+        <div class="item" data-section="statsSection">Estatisticas</div>
       </div>
       <div class="gestao-content">
+        <div id="gestaoBack" class="gestao-back" style="display:none">&lt;</div>
         <div id="uploadSection" class="gestao-section">
           <h2>Enviar nova ecografia</h2>
           <form id="uploadForm">

--- a/views/partials/header_main.ejs
+++ b/views/partials/header_main.ejs
@@ -1,3 +1,4 @@
 <header class="glass scroll-fade">
   <h1><%= title || 'EcoShare' %></h1>
+  <img id="profilePic" class="profile-pic" src="https://placehold.co/32x32" alt="Perfil">
 </header>


### PR DESCRIPTION
## Resumo
- transforma o menu da janela Gestão em uma lista vertical
- adiciona botão de voltar no topo da área de conteúdo
- ajusta estilos para o novo layout
- adiciona imagem de perfil padrão no cabeçalho

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ccc23b6d48329a47393c7cc634f3e