### PR TITLE
Fix profile pic location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,5 +14,6 @@ The project uses Node.js with Jest for testing.
 * Add or update tests in `test/` when making code changes.
 * Reference relevant files or terminal output in PR summaries using the provided citation format.
 * Sempre explique as coisas em português.
+* A foto do perfil deve aparecer somente no **dock** da página principal, não no cabeçalho.
 
 O `README.md` detalha o passo a passo para instalar e executar o projeto em Windows, Linux e macOS. Caso as etapas mudem, mantenha esse arquivo atualizado.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Para executar a suíte de testes utilize `npm test`.
 
 A interface web disponível em `/` permite enviar novas ecografias e visualizar a lista de imagens cadastradas.
 Há um **dock** fixo na parte inferior com a aplicação **Gestão**.
-Ao abrir essa aplicação surge uma janela única com as opções de Enviar, Lista, Usuários, Mensagem e Estatísticas,
+Nele aparece a foto do usuário logado, ao lado do menu de logout.
+Ao abrir a aplicação de gestão surge uma janela única com as opções de Enviar, Lista, Usuários, Mensagem e Estatísticas,
 que são exibidas na própria janela conforme o item escolhido.
 Os usuários possuem papéis de **admin**, **medico** ou **paciente**. Somente administradores conseguem gerenciar usuários.
 Pacientes enxergam apenas seus próprios exames.

--- a/test/profile_image.test.js
+++ b/test/profile_image.test.js
@@ -9,7 +9,7 @@ describe('Imagem de perfil', () => {
     await agent.post('/login').send({ username: 'admin', password: 'admin' });
   });
 
-  test('header usa placeholder de perfil', async () => {
+  test('dock exibe placeholder de perfil', async () => {
     const res = await agent.get('/');
     expect(res.status).toBe(200);
     expect(res.text).toContain('https://placehold.co/32x32');

--- a/views/partials/header_main.ejs
+++ b/views/partials/header_main.ejs
@@ -1,4 +1,3 @@
 <header class="glass scroll-fade">
   <h1><%= title || 'EcoShare' %></h1>
-  <img id="profilePic" class="profile-pic" src="https://placehold.co/32x32" alt="Perfil">
 </header>


### PR DESCRIPTION
## Summary
- remove profile image from header so it only appears in the dock
- document in README and AGENTS that the profile picture stays in the dock
- update profile image test description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd375f738832995819c8d11bf0794