### PR TITLE
Aplica fundo com imagem e layout responsivo do envio

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -17,6 +17,19 @@ body {
   color: var(--text-light);
   margin: 0;
   padding: 0;
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: url('/bg.jpg') center/cover no-repeat;
+  opacity: 0.5;
+  z-index: -1;
 }
 
 
@@ -131,6 +144,22 @@ header {
 
 .gestao-form button[type='submit'] {
   flex-basis: 100%;
+}
+
+#uploadForm {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr;
+}
+
+#uploadForm button[type='submit'] {
+  grid-column: 1 / -1;
+}
+
+@media (min-width: 50vw) {
+  #uploadForm {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .tabs {


### PR DESCRIPTION
## Summary
- adiciona imagem `bg.jpg` como fundo com 50% de opacidade
- usa grid no formulário de envio com 1 ou 2 colunas conforme a largura

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce90a2c8483299a408a9da30b8b7d