### PR TITLE
Remove headers from internal pages

### DIFF
--- a/test/pages.test.js
+++ b/test/pages.test.js
@@ -37,4 +37,32 @@ describe('Paginas publicas', () => {
     expect(res.status).toBe(200);
     expect(res.text).toContain('gsi-material-button');
   });
+
+  test('login exibe cabe\xE7alho com nome', async () => {
+    const res = await request(app).get('/login.html');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('<header');
+    expect(res.text).toContain('EcoShare');
+  });
+
+  test('painel n\xE3o tem cabe\xE7alho', async () => {
+    const res = await request(app).get('/painel.html');
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('<header');
+  });
+
+  test('cpf n\xE3o tem cabe\xE7alho', async () => {
+    const res = await request(app).get('/cpf.html');
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('<header');
+  });
+
+  test('politica e termos sem cabe\xE7alho', async () => {
+    let res = await request(app).get('/politica');
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('<header');
+    res = await request(app).get('/termos');
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('<header');
+  });
 });

--- a/views/cpf.ejs
+++ b/views/cpf.ejs
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<%- include('partials/header_main', { title: 'EcoShare' }) %>
   <div class='container glass login-container scroll-fade'>
     <form id="cpfForm" method="post" action="/api/me/cpf">
       <div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<%- include('partials/header_main', { title: 'EcoShare' }) %>
   <div id="gestaoWindow" class="window">
     <div class="window-header">
       <span>Gestão</span>

--- a/views/painel.ejs
+++ b/views/painel.ejs
@@ -12,7 +12,6 @@
 <body>
   <div class="dashboard-layout">
     <aside class="sidebar glass scroll-fade">
-      <h1><img src="/icons/home.svg" class="icon" alt=""> EcoShare</h1>
       <button id="logoutBtn" class="logout-btn"><img src="/icons/log-out.svg" class="icon" alt=""> Sair</button>
     </aside>
     <main class="dashboard-content">

--- a/views/politica.ejs
+++ b/views/politica.ejs
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<%- include('partials/header_simple', { title: 'Política de Privacidade' }) %>
   <div class='container glass scroll-fade'>
     <h2>Proteção de dados</h2>
     <p>Respeitamos sua privacidade e utilizamos suas informações apenas para liberar os laudos de forma segura.</p>

--- a/views/share.ejs
+++ b/views/share.ejs
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<%- include('partials/header_main', { title: 'Visualizar Laudo' }) %>
   <div class='container glass scroll-fade'>
     <p>Informe o CPF para acessar o arquivo.</p>
     <form id="cpfForm">

--- a/views/termos.ejs
+++ b/views/termos.ejs
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-<%- include('partials/header_simple', { title: 'Termos de Serviço' }) %>
   <div class='container glass scroll-fade'>
     <h2>Uso do sistema</h2>
     <p>O envio de arquivos é restrito a usuários autorizados e os laudos compartilhados possuem acesso temporário.</p>


### PR DESCRIPTION
## Summary
- remove header includes from CPF, share, política, termos e index
- ocultar nome no painel
- garantir em testes que apenas a página de login possui cabeçalho

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cea9696dc8329a0af255624ec3cd1