### PR TITLE
Atualiza nome para ExamShare e ajusta login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EcoShare
+# ExamShare
 
 Sistema para disponibilizar ecografias online com upload, compartilhamento por WhatsApp e visualização de laudos em PDF.
 

--- a/public/style.css
+++ b/public/style.css
@@ -308,6 +308,7 @@ button:hover {
 }
 
 .gsi-material-button {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -325,7 +326,6 @@ button:hover {
   transition: box-shadow .2s ease;
   white-space: nowrap;
   width: 100%;
-  max-width: 400px;
 }
 
 .gsi-material-button .gsi-material-button-icon {
@@ -359,6 +359,7 @@ button:hover {
   top: 0;
   opacity: 0;
   position: absolute;
+  pointer-events: none;
 }
 
 .gsi-material-button:disabled {
@@ -486,6 +487,10 @@ footer.footer {
   max-width: 420px;
   padding: 40px;
   text-align: center;
+}
+.login-logo {
+  max-width: 180px;
+  margin-bottom: 20px;
 }
 
 .login-card label {

--- a/test/pages.test.js
+++ b/test/pages.test.js
@@ -38,12 +38,11 @@ describe('Paginas publicas', () => {
     expect(res.text).toContain('gsi-material-button');
   });
 
-  test('login exibe cabe\xE7alho com nome', async () => {
-    const res = await request(app).get('/login.html');
-    expect(res.status).toBe(200);
-    expect(res.text).toContain('<header');
-    expect(res.text).toContain('EcoShare');
-  });
+test('login n\xE3o exibe cabe\xE7alho', async () => {
+  const res = await request(app).get('/login.html');
+  expect(res.status).toBe(200);
+  expect(res.text).not.toContain('<header');
+});
 
   test('painel n\xE3o tem cabe\xE7alho', async () => {
     const res = await request(app).get('/painel.html');

--- a/views/cpf.ejs
+++ b/views/cpf.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CPF - EcoShare</title>
+  <title>CPF - ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>EcoShare</title>
+  <title>ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login - EcoShare</title>
+  <title>Login - ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
 </head>
 <body class="login-page">
-<%- include('partials/header_simple', { title: 'EcoShare' }) %>
   <div class="login-wrapper">
     <div class="login-card glass scroll-fade">
+      <img src="/logo.png" alt="ExamShare" class="login-logo">
       <h2 class="login-title">Bem-vindo de volta</h2>
       <form id="loginForm" method="post" action="/login">
         <label><img src="/icons/user.svg" class="icon" alt=""> Usuário</label>

--- a/views/painel.ejs
+++ b/views/painel.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Painel - EcoShare</title>
+  <title>Painel - ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/views/partials/header_main.ejs
+++ b/views/partials/header_main.ejs
@@ -1,3 +1,3 @@
 <header class="glass scroll-fade">
-  <h1><img src="/icons/home.svg" class="icon" alt=""> <%= title || 'EcoShare' %></h1>
+  <h1><img src="/icons/home.svg" class="icon" alt=""> <%= title || 'ExamShare' %></h1>
 </header>

--- a/views/partials/header_simple.ejs
+++ b/views/partials/header_simple.ejs
@@ -1,3 +1,3 @@
 <header class="glass scroll-fade">
-  <h1><img src="/icons/home.svg" class="icon" alt=""> <%= title || 'EcoShare' %></h1>
+  <h1><img src="/icons/home.svg" class="icon" alt=""> <%= title || 'ExamShare' %></h1>
 </header>

--- a/views/politica.ejs
+++ b/views/politica.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Política de Privacidade - EcoShare</title>
+  <title>Política de Privacidade - ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/views/share.ejs
+++ b/views/share.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>EcoShare - Laudo</title>
+  <title>ExamShare - Laudo</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/views/termos.ejs
+++ b/views/termos.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Termos de Serviço - EcoShare</title>
+  <title>Termos de Serviço - ExamShare</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -13,7 +13,7 @@
   <div class='container glass scroll-fade'>
     <h2>Uso do sistema</h2>
     <p>O envio de arquivos é restrito a usuários autorizados e os laudos compartilhados possuem acesso temporário.</p>
-    <p>Ao utilizar o EcoShare você concorda em utilizar os serviços apenas para fins legais e respeitar a privacidade dos pacientes.</p>
+    <p>Ao utilizar o ExamShare você concorda em utilizar os serviços apenas para fins legais e respeitar a privacidade dos pacientes.</p>
   </div>
   <footer class="footer glass">
     <a href="/"> <img src="/icons/arrow-left.svg" class="icon" alt=""> Voltar</a>


### PR DESCRIPTION
## Summary
- renomeia EcoShare para ExamShare
- remove cabeçalho da tela de login e mostra logo
- corrige largura do botão de login do Google e sobreposição de clique
- ajusta teste da página de login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ced8201b88329a1b3cebb2e2d9d81