### PR TITLE
Menu do perfil abre ao passar o mouse

### DIFF
--- a/public/common.js
+++ b/public/common.js
@@ -10,6 +10,13 @@ async function initProfileMenu() {
       if (me.picture) pic.src = me.picture;
     }
   } catch (_) {}
+  const container = pic.parentElement;
+  container.addEventListener('mouseenter', () => {
+    dropdown.classList.add('show');
+  });
+  container.addEventListener('mouseleave', () => {
+    dropdown.classList.remove('show');
+  });
   pic.addEventListener('click', () => {
     dropdown.classList.toggle('show');
   });
@@ -18,4 +25,8 @@ async function initProfileMenu() {
       dropdown.classList.remove('show');
     }
   });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { initProfileMenu };
 }

--- a/public/style.css
+++ b/public/style.css
@@ -470,6 +470,10 @@ footer.footer {
 .profile-dropdown.show {
   display: block;
 }
+
+.profile-menu:hover .profile-dropdown {
+  display: block;
+}
 .scroll-fade {
   opacity: 0;
   transform: translateY(20px);

--- a/test/profile_menu_hover.test.js
+++ b/test/profile_menu_hover.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+global.fetch = () => Promise.resolve({ ok: true, json: async () => ({}) });
+
+const { initProfileMenu } = require('../public/common.js');
+
+describe('Dropup do perfil', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="profile-menu">
+        <img id="profilePic">
+        <div id="profileDropdown" class="profile-dropdown"></div>
+      </div>`;
+  });
+
+  test('abre ao passar o mouse', async () => {
+    await initProfileMenu();
+    const menu = document.querySelector('.profile-menu');
+    const dropdown = document.getElementById('profileDropdown');
+    menu.dispatchEvent(new Event('mouseenter'));
+    expect(dropdown.classList.contains('show')).toBe(true);
+    menu.dispatchEvent(new Event('mouseleave'));
+    expect(dropdown.classList.contains('show')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo
- exibir o dropup do perfil ao passar o mouse
- manter suporte a clique e exportar `initProfileMenu`
- garantir o comportamento com teste em jsdom

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cf1c0cd0c8329910354407fbb3633