### PR TITLE
Perfil: dropup abre por clique

### DIFF
--- a/public/common.js
+++ b/public/common.js
@@ -10,13 +10,6 @@ async function initProfileMenu() {
       if (me.picture) pic.src = me.picture;
     }
   } catch (_) {}
-  const container = pic.parentElement;
-  container.addEventListener('mouseenter', () => {
-    dropdown.classList.add('show');
-  });
-  container.addEventListener('mouseleave', () => {
-    dropdown.classList.remove('show');
-  });
   pic.addEventListener('click', () => {
     dropdown.classList.toggle('show');
   });

--- a/public/style.css
+++ b/public/style.css
@@ -457,13 +457,19 @@ footer.footer {
   text-decoration: none;
   color: inherit;
   background: none;
-  border: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   text-align: left;
   width: 100%;
 }
 .profile-dropdown a:hover,
 .profile-dropdown button:hover {
-  background: var(--neutral);
+  background: var(--primary);
+  color: #fff;
+}
+.profile-dropdown a:hover .icon,
+.profile-dropdown button:hover .icon {
+  filter: brightness(0) invert(1);
 }
 
 
@@ -471,9 +477,6 @@ footer.footer {
   display: block;
 }
 
-.profile-menu:hover .profile-dropdown {
-  display: block;
-}
 .scroll-fade {
   opacity: 0;
   transform: translateY(20px);

--- a/test/profile_menu_hover.test.js
+++ b/test/profile_menu_hover.test.js
@@ -15,13 +15,13 @@ describe('Dropup do perfil', () => {
       </div>`;
   });
 
-  test('abre ao passar o mouse', async () => {
+  test('abre ao clicar', async () => {
     await initProfileMenu();
-    const menu = document.querySelector('.profile-menu');
+    const pic = document.getElementById('profilePic');
     const dropdown = document.getElementById('profileDropdown');
-    menu.dispatchEvent(new Event('mouseenter'));
+    pic.dispatchEvent(new Event('click'));
     expect(dropdown.classList.contains('show')).toBe(true);
-    menu.dispatchEvent(new Event('mouseleave'));
+    document.dispatchEvent(new Event('click'));
     expect(dropdown.classList.contains('show')).toBe(false);
   });
 });


### PR DESCRIPTION
## Resumo
- remove o disparo do menu de perfil ao passar o mouse
- aplica bordas e hover iguais ao menu de gestão
- atualiza o teste do dropup do perfil

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf367727c83299280f971b2cce853