### PR TITLE
Corrige largura e hover do menu de perfil

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -448,6 +448,8 @@ footer.footer {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   padding: 6px 0;
   z-index: 1000;
+  width: max-content;
+  color: var(--text-light);
 }
 
 .profile-dropdown a,
@@ -461,6 +463,9 @@ footer.footer {
   border-radius: var(--radius-sm);
   text-align: left;
   width: 100%;
+}
+.profile-dropdown .icon {
+  filter: none;
 }
 .profile-dropdown a:hover,
 .profile-dropdown button:hover {

--- a/test/profile_dropdown_style.test.js
+++ b/test/profile_dropdown_style.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Estilos do dropup do perfil', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../public/style.css'), 'utf8');
+
+  test('largura e cor padrao', () => {
+    expect(css).toMatch(/\.profile-dropdown\s*{[^}]*width: max-content;[^}]*color: var\(--text-light\);/s);
+  });
+
+  test('icones sem filtro inicial', () => {
+    expect(css).toMatch(/\.profile-dropdown .icon\s*{[^}]*filter: none;[^}]*}/);
+  });
+});


### PR DESCRIPTION
## Resumo
- ajusta largura do dropup de perfil usando `max-content`
- impede que o hover do dock afete todos os itens do menu
- adiciona testes de CSS para o menu

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf564681c8329bc719f468d4d934a